### PR TITLE
Explicit module to make GHC -haddock happy

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,6 +3,8 @@
 
 -- | A helpful client for debugging connections.
 
+module Main (main) where
+
 import qualified Data.Text.IO as T
 import           Control.Exception
 import qualified Data.Text as T


### PR DESCRIPTION
When building with `-haddock`, GHC expects the comments at the top of modules to have a module declaration to attach to, otherwise it throws an error.

I noticed this because haskell-language-server recommends building dependencies with `-haddock` in order to display documentation in the editor.