### PR TITLE
nvarchar/varchar escaping

### DIFF
--- a/src/Database/ODBC/SQLServer.hs
+++ b/src/Database/ODBC/SQLServer.hs
@@ -515,10 +515,10 @@ escapeChar8 ch =
 
 -- | A very conservative character escape.
 escapeChar :: Char -> Text
-escapeChar ch =
-  if allowedChar ch
-     then T.singleton ch
-     else "'+NCHAR(" <> Formatting.sformat Formatting.int (fromEnum ch) <> ")+'"
+escapeChar =
+  \case 
+    '\'' -> "''"
+    ch -> T.singleton ch
 
 -- | Is the character allowed to be printed unescaped? We only print a
 -- small subset of ASCII just for visually debugging later

--- a/src/Database/ODBC/SQLServer.hs
+++ b/src/Database/ODBC/SQLServer.hs
@@ -508,10 +508,10 @@ renderFractional x = trim (printf "%.7f" (realToFrac x :: Double) :: String)
 
 -- | A very conservative character escape.
 escapeChar8 :: Word8 -> Text
-escapeChar8 ch =
-  if allowedChar (toEnum (fromIntegral ch))
-     then T.singleton (toEnum (fromIntegral ch))
-     else "'+CHAR(" <> Formatting.sformat Formatting.int ch <> ")+'"
+escapeChar8 =
+  \case 
+    39 -> "''"
+    ch -> T.singleton (toEnum (fromIntegral ch))
 
 -- | A very conservative character escape.
 escapeChar :: Char -> Text

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -124,6 +124,7 @@ regressions = do
 bigData :: Spec
 bigData = do
   roundtrip @Text "2MB text" "Text" "ntext" (T.replicate (1024*1024*2) "A")
+  roundtrip @Text "2MB text special characters" "Text" "ntext" (T.replicate (1024*1024*2) "<")
   roundtrip @ByteString "2MB binary" "ByteString" "text" (S.replicate (1024*1024*2) 97)
 
 conversionTo :: Spec

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -126,6 +126,7 @@ bigData = do
   roundtrip @Text "2MB text" "Text" "ntext" (T.replicate (1024*1024*2) "A")
   roundtrip @Text "2MB text special characters" "Text" "ntext" (T.replicate (1024*1024*2) "<")
   roundtrip @ByteString "2MB binary" "ByteString" "text" (S.replicate (1024*1024*2) 97)
+  roundtrip @ByteString "2MB binary special characters" "ByteString" "text" (S.replicate (1024*1024*2) 60)
 
 conversionTo :: Spec
 conversionTo = do


### PR DESCRIPTION
See #32.  The first commit involving nvarchar passes tests.  The second does not.