### PR TITLE
Add binding of parameters for text/binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,9 @@ for C/en_AU.UTF-8/C/C/C/C
 ```
 
 use driver 13 or [see here for more detail](https://github.com/fpco/odbc/issues/17).
+
+## Contributors
+
+* Spencer Janssen
+* Yo Eight
+* Marco Z

--- a/cbits/odbc.c
+++ b/cbits/odbc.c
@@ -160,11 +160,44 @@ void odbc_SQLFreeStmt(SQLHSTMT *hstmt){
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Params
+
+SQLRETURN odbc_SQLBindParameter(
+  EnvAndDbc*    envAndDbc,
+  SQLHSTMT*     statement_handle,
+  SQLUSMALLINT  parameter_number,
+  SQLSMALLINT   value_type,
+  SQLSMALLINT   parameter_type,
+  SQLULEN       column_size,
+  SQLPOINTER    parameter_value_ptr,
+  SQLLEN        buffer_length,
+  SQLLEN*       buffer_length_ptr
+  ) {
+  RETCODE r = SQLBindParameter(
+    *statement_handle,
+    parameter_number,
+    SQL_PARAM_INPUT,
+    value_type,
+    parameter_type,
+    column_size,
+    0,
+    parameter_value_ptr,
+    buffer_length,
+    buffer_length_ptr
+    );
+  if (r == SQL_ERROR)
+    odbc_ProcessLogMessages(envAndDbc, SQL_HANDLE_STMT, *statement_handle, "odbc_SQLBindParameter", FALSE);
+  return r;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Execute
 
 RETCODE odbc_SQLExecDirectW(EnvAndDbc *envAndDbc, SQLHSTMT *hstmt, SQLWCHAR *stmt, SQLINTEGER len){
   RETCODE r = SQLExecDirectW(*hstmt, stmt, len);
-  if (r == SQL_ERROR) odbc_ProcessLogMessages(envAndDbc, SQL_HANDLE_STMT, *hstmt, "odbc_SQLExecDirectW", FALSE);
+  if (r == SQL_ERROR) {
+    odbc_ProcessLogMessages(envAndDbc, SQL_HANDLE_STMT, *hstmt, "odbc_SQLExecDirectW", FALSE);
+  }
   return r;
 }
 

--- a/odbc.cabal
+++ b/odbc.cabal
@@ -5,7 +5,7 @@ description: Haskell binding to the ODBC API. This has been tested
              suite runs on OS X, Windows and Linux.
 copyright: FP Complete 2018
 maintainer: chrisdone@fpcomplete.com
-version:             0.2.3
+version:             0.2.4
 license:             BSD3
 license-file:        LICENSE
 build-type:          Simple

--- a/src/Database/ODBC/Internal.hs
+++ b/src/Database/ODBC/Internal.hs
@@ -105,17 +105,25 @@ instance Exception ODBCException
 -- | A value used for input/output with the database.
 data Value
   = TextValue !Text
-    -- ^ A Unicode text value.
-  | ByteStringValue !ByteString
-    -- ^ A vector of bytes. It might be binary, or a string, but we
-    -- don't know the encoding. Use 'Data.Text.Encoding.decodeUtf8' if
-    -- the string is UTF-8 encoded, or
-    -- 'Data.Text.Encoding.decodeUtf16LE' if it is UTF-16 encoded. For
-    -- other encodings, see the Haskell text-icu package.  For raw
-    -- binary, see 'BinaryValue'.
+    -- ^ A Unicode text value. This maps to nvarchar in SQL
+    -- Server. Use this for text.
   | BinaryValue !Binary
     -- ^ Only a vector of bytes. Intended for binary data, not for
-    -- ASCII text.
+    -- ASCII text. This maps to varbinary or binary in SQL Server.
+  | ByteStringValue !ByteString
+    -- ^ A vector of bytes. It might be binary, or a string, but we
+    -- don't know the encoding. It maps to @varchar@ in the database
+    -- in SQL Server.
+    --
+    -- DO NOT USE THIS TYPE IF YOU CAN AVOID IT: This type does not
+    -- have a reliable transmission via parameters, and therefore is
+    -- encoded within the query as @CHAR(x) + ...@  where x is a
+    -- character outside of alphanumeric characters.
+    --
+    -- If you must: Use 'Data.Text.Encoding.decodeUtf8' if the string
+    -- is UTF-8 encoded, or 'Data.Text.Encoding.decodeUtf16LE' if it
+    -- is UTF-16 encoded. For other encodings, see the Haskell
+    -- text-icu package.  For raw binary, see 'BinaryValue'.
   | BoolValue !Bool
     -- ^ A simple boolean.
   | DoubleValue !Double

--- a/src/Database/ODBC/SQLServer.hs
+++ b/src/Database/ODBC/SQLServer.hs
@@ -308,16 +308,20 @@ instance ToSql Text where
 instance ToSql LT.Text where
   toSql = toSql . TextValue . LT.toStrict
 
--- | Corresponds to TEXT (non-Unicode) of SQL Server. For proper
--- BINARY, see the 'Binary' type.
+-- | AVOID THIS TYPE: Corresponds to TEXT/VARCHAR (non-Unicode) of SQL
+-- Server. For proper BINARY, see the 'Binary' type. For proper text,
+-- use 'Text'.
 instance ToSql ByteString where
   toSql = toSql . ByteStringValue
 
+-- | Corresponds to TEXT/VARCHAR (non-Unicode) of SQL
+-- Server. For proper BINARY, see the 'Binary' type. For proper text,
+-- use 'Text'.
 instance ToSql Internal.Binary where
   toSql = toSql . BinaryValue
 
--- | Corresponds to TEXT (non-Unicode) of SQL Server. For Unicode, use
--- the 'Text' type.
+-- | AVOID THIS TYPE: Corresponds to TEXT (non-Unicode) of SQL
+-- Server. For Unicode, use the 'Text' type.
 instance ToSql L.ByteString where
   toSql = toSql . ByteStringValue . L.toStrict
 

--- a/src/Database/ODBC/SQLServer.hs
+++ b/src/Database/ODBC/SQLServer.hs
@@ -58,6 +58,7 @@ module Database.ODBC.SQLServer
   , renderParts
   , renderPart
   , renderValue
+  , renderedAndParams
   ) where
 
 
@@ -88,7 +89,7 @@ import qualified Data.Text.Lazy as LT
 import           Data.Time
 import           Data.Word
 import           Database.ODBC.Conversion
-import           Database.ODBC.Internal (Value(..), Connection)
+import           Database.ODBC.Internal (Param(..), Value(..), Connection)
 import qualified Database.ODBC.Internal as Internal
 import qualified Formatting
 import           Formatting ((%))
@@ -403,11 +404,12 @@ query ::
   => Connection -- ^ A connection to the database.
   -> Query -- ^ SQL query.
   -> m [row]
-query c (Query ps) = do
-  rows <- Internal.query c (renderParts (toList ps))
+query c q = do
+  rows <- Internal.queryWithParams c rendered params
   case mapM (fromRow . map snd) rows of
     Right rows' -> pure rows'
     Left e -> liftIO (throwIO (Internal.DataRetrievalError e))
+  where (rendered, params) = renderedAndParams q
 
 -- | Render a query to a plain text string. Useful for debugging and
 -- testing.
@@ -427,15 +429,17 @@ stream ::
   -- evaluated each iteration.
   -> m state
   -- ^ Final result, produced by the stepper function.
-stream c (Query ps) cont nil =
-  Internal.stream
+stream c q cont nil =
+  Internal.streamWithParams
     c
-    (renderParts (toList ps))
+    rendered
+    params
     (\state row ->
        case fromRow (map snd row) of
          Left e -> liftIO (throwIO (Internal.DataRetrievalError e))
          Right row' -> cont state row')
     nil
+  where (rendered, params) = renderedAndParams q
 
 -- | Execute a statement on the database.
 exec ::
@@ -443,10 +447,43 @@ exec ::
   => Connection -- ^ A connection to the database.
   -> Query -- ^ SQL statement.
   -> m ()
-exec c (Query ps) = Internal.exec c (renderParts (toList ps))
+exec c q = Internal.execWithParams c rendered params
+  where
+    (rendered, params) = renderedAndParams q
 
 --------------------------------------------------------------------------------
 -- Query building
+
+-- | Splits a query up into a parametrized text with ? and the params
+-- used.
+renderedAndParams :: Query -> (Text, [Param])
+renderedAndParams q = (renderParts parts', params)
+  where
+    parts' =
+      map
+        (\case
+           ValuePart v
+             | Just {} <- valueToParam v -> TextPart "?"
+           p -> p)
+        parts
+    params =
+      mapMaybe
+        (\case
+           ValuePart v
+             | Just p <- valueToParam v -> Just p
+           _ -> Nothing)
+        parts
+    parts = toList (queryParts q)
+
+-- | Convert a value to a parameter, if possible. Values that aren't
+-- parameters will be inlined in the query string directly. SQL Server
+-- is capable of caching constants, so this isn't an issue.
+valueToParam :: Value -> Maybe Param
+valueToParam =
+  \case
+    TextValue v | not (T.null v) -> pure $ TextParam v
+    BinaryValue v@(Internal.Binary s) | not (S.null s) -> pure $ BinaryParam v
+    _ -> Nothing
 
 -- | Access the parts of a query.
 queryParts :: Query -> Seq Part
@@ -540,6 +577,8 @@ allowedChar c = (isAlphaNum c && isAscii c) || elem c (" ,.-_" :: [Char])
 --
 -- For if you're working with an API that assumes queries and
 -- parameters are separated.
+--
+-- @since 0.2.4
 splitQueryParametrized :: Query -> (Text, [Value])
 splitQueryParametrized q = (text, params)
   where
@@ -559,6 +598,8 @@ splitQueryParametrized q = (text, params)
 
 -- | Join a query with ? in it with the values into a Query. Checks
 -- that they match.
+--
+-- @since 0.2.4
 joinQueryParametrized :: Text -> [Value] -> Either String Query
 joinQueryParametrized text0 params0 = do
   parts <- Atto.parseOnly partsParser text0


### PR DESCRIPTION
This adds parametrization of the types `Text` and `Binary`, leaving `ByteString` encoded in the query string.

* Because `Text` is stored as UTF-16 in Haskell, transferred via odbc in UTF-16, this is reliable for `nvarchar`.
* Because `Binary` is sent as an opaque buffer of arbitrary size (use `varbinary(max)` to avoid truncation exceptions), this is also reliable for `varbinary`.

The `ValueByteString` which maps to a `varchar` is not reliable. I reproduced @spencerjanssen's observation that characters outside of a specific range are converted to `?`. This may completely depend on environment and I don't think can be made reliable; I haven't found any documentation that states clearly how to avoid this. But given that standard modern advice is to avoid this type and either use `nvarchar` for Unicode text and `varbinary` for binary, I think we are covering the two important cases reliably. This remains being encoded as `CHAR(x)+CHAR(y)`.

I've updated the documentation to reflect this: avoid using `ByteString` and `ValueByteString`, opt instead for either text or binary.

I won't go as far as deprecating that constructor, because people who Know What They're Doing might use it with e.g. Latin1 or ASCII or something. But as a future breaking change it may be worth using a newtype like the `Binary` type, called e.g. `AmbiguousString` which will draw attention to the docs and make it explicit that they've read and made a choice. For now, though, I'm content to just add a new non-breaking-change feature.

Also, @spencerjanssen I've made only non-null text/binary be parametrized. I noticed that there's some funny business there with empty strings, but note that it's cheap to use the existing encoding of `N''` (nvarchar) or `0x` (binary) for empty variants which isn't much longer than `?` and binding an extra parameter.

This passes [tests set to 500 samples](https://gist.github.com/chrisdone/7d0ccb22e424bd29db9ce97200607bf0).