### PR TITLE
Fix build on GHC 9.0.1

### DIFF
--- a/src/Database/ODBC/Internal.hs
+++ b/src/Database/ODBC/Internal.hs
@@ -407,10 +407,11 @@ withExecDirect dbc string params cont =
 
 -- | Run the function with a statement.
 withStmt :: Ptr EnvAndDbc -> (forall s. SQLHSTMT s -> IO a) -> IO a
-withStmt hdbc =
+withStmt hdbc cont =
   bracket
     (assertNotNull "odbc_SQLAllocStmt" (odbc_SQLAllocStmt hdbc))
     odbc_SQLFreeStmt
+    cont
 
 -- | Run an action in a bound thread. This is neccessary due to the
 -- interaction with signals in ODBC and GHC's runtime.


### PR DESCRIPTION
The library fails to build on GHC 9.0.1 due to [type system changes](https://downloads.haskell.org/ghc/9.0.1/docs/html/users_guide/exts/rank_polymorphism.html#simple-subsumption).  I tested with the nightly-2021-10-29 Stack resolver.