### PR TITLE
expose SQLSTATE through ODBCException

### DIFF
--- a/cbits/odbc.c
+++ b/cbits/odbc.c
@@ -106,8 +106,8 @@ EnvAndDbc *odbc_AllocEnvAndDbc(){
         EnvAndDbc *envAndDbc = malloc(sizeof *envAndDbc);
         envAndDbc->env = env;
         envAndDbc->dbc = dbc;
-        envAndDbc->error = malloc(MAXBUFLEN);
-        envAndDbc->sqlState = malloc(MAXBUFLEN);
+        envAndDbc->error = malloc(SQL_MAX_MESSAGE_LENGTH);
+        envAndDbc->sqlState = malloc(6);
         return envAndDbc;
       }
     }

--- a/cbits/odbc.c
+++ b/cbits/odbc.c
@@ -107,6 +107,7 @@ EnvAndDbc *odbc_AllocEnvAndDbc(){
         envAndDbc->env = env;
         envAndDbc->dbc = dbc;
         envAndDbc->error = malloc(SQL_MAX_MESSAGE_LENGTH);
+        # SQLSTATE is a five-character code, see https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/appendix-a-odbc-error-codes?view=sql-server-ver15
         envAndDbc->sqlState = malloc(6);
         return envAndDbc;
       }

--- a/cbits/odbc.c
+++ b/cbits/odbc.c
@@ -23,11 +23,16 @@ typedef struct EnvAndDbc {
   SQLHENV *env;
   SQLHDBC *dbc;
   char *error;
+  char *sqlState;
   // Allocated once in odbc_AllocEnvAndDbc and freed once in odbc_FreeEnvAndDbc.
 } EnvAndDbc;
 
 char *odbc_error(EnvAndDbc *envAndDbc){
   return envAndDbc->error;
+}
+
+char *odbc_sqlState(EnvAndDbc *envAndDbc){
+  return envAndDbc->sqlState;
 }
 
 void odbc_ProcessLogMessages(EnvAndDbc *envAndDbc, SQLSMALLINT plm_handle_type, SQLHANDLE plm_handle, char *logstring, int ConnInd);
@@ -102,6 +107,7 @@ EnvAndDbc *odbc_AllocEnvAndDbc(){
         envAndDbc->env = env;
         envAndDbc->dbc = dbc;
         envAndDbc->error = malloc(MAXBUFLEN);
+        envAndDbc->sqlState = malloc(MAXBUFLEN);
         return envAndDbc;
       }
     }
@@ -110,6 +116,7 @@ EnvAndDbc *odbc_AllocEnvAndDbc(){
 
 void odbc_FreeEnvAndDbc(EnvAndDbc *envAndDbc){
   free(envAndDbc->error);
+  free(envAndDbc->sqlState);
   odbc_SQLFreeDbc(envAndDbc->dbc);
   odbc_SQLFreeEnv(envAndDbc->env);
   free(envAndDbc);
@@ -273,7 +280,6 @@ void odbc_ProcessLogMessages(EnvAndDbc *envAndDbc, SQLSMALLINT plm_handle_type, 
 
   // These are not interesting for our use-case, but needed by
   // SQLGetDiagRec:
-  UCHAR plm_szSqlState[MAXBUFLEN] = "";
   SDWORD plm_pfNativeError = 0L;
   SWORD plm_pcbErrorMsg = 0;
 
@@ -283,7 +289,7 @@ void odbc_ProcessLogMessages(EnvAndDbc *envAndDbc, SQLSMALLINT plm_handle_type, 
   SQLGetDiagRec(plm_handle_type,
                 plm_handle,
                 plg_record_number,
-                plm_szSqlState,
+                (SQLCHAR *)envAndDbc->sqlState,
                 &plm_pfNativeError,
                 (SQLCHAR *)envAndDbc->error,
                 copy_this_many_bytes,

--- a/src/Database/ODBC/Internal.hs
+++ b/src/Database/ODBC/Internal.hs
@@ -83,7 +83,7 @@ data ODBCException
   = UnsuccessfulReturnCode !String
                            !Int16 -- ^ Return code
                            !String -- ^ Error message
-                           !(Maybe String) -- ^ SQL state code
+                           !(Maybe String) -- ^ SQL state code, see https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/appendix-a-odbc-error-codes?view=sql-server-ver15
     -- ^ An ODBC operation failed with the given return code.
   | AllocationReturnedNull !String
     -- ^ Allocating an ODBC resource failed.
@@ -1003,7 +1003,8 @@ assertSuccessOrNoData dbc label m = do
       sqlState <- fetchSqlState dbc
       throwIO (UnsuccessfulReturnCode label (coerce retcode) string sqlState)
 
--- | Fetch SQLSTATE, an alphanumeric code which provides detailed information about the cause of a warning or error.
+-- | Fetch SQLSTATE, an alphanumeric code which provides detailed information about the cause of a warning or error
+-- see https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/appendix-a-odbc-error-codes?view=sql-server-ver15
 fetchSqlState :: Ptr EnvAndDbc -> IO (Maybe String)
 fetchSqlState dbc = do
   ptr <- odbc_sqlState dbc


### PR DESCRIPTION
This PR makes an attempt to add [SQLSTATE](https://docs.microsoft.com/en-us/sql/relational-databases/native-client-odbc-error-messages/sqlstate-odbc-error-codes?view=sql-server-ver15), a 5 char diagnostic code useful in classifying database errors, to `ODBCException` type. It helps applications to process exceptions better. 